### PR TITLE
feat: add a `graphql-gw version` command to get the build version

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -4,8 +4,12 @@ import (
 	_ "github.com/chirino/graphql-gw/internal/cmd/new"
 	"github.com/chirino/graphql-gw/internal/cmd/root"
 	_ "github.com/chirino/graphql-gw/internal/cmd/serve"
+	"github.com/chirino/graphql-gw/internal/cmd/version"
 )
 
-func Main() {
+type VersionConfig = version.VersionConfig
+
+func Main(versionConfig VersionConfig) {
+	version.Config = versionConfig
 	root.Main()
 }

--- a/internal/cmd/version/cmd.go
+++ b/internal/cmd/version/cmd.go
@@ -1,0 +1,38 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/chirino/graphql-gw/internal/cmd/root"
+	"github.com/spf13/cobra"
+)
+
+type VersionConfig struct {
+	Version string
+	Commit  string
+	Date    string
+}
+
+var Config = VersionConfig{
+	Version: "dev",
+	Commit:  "none",
+	Date:    "unknown",
+}
+
+var (
+	Command = &cobra.Command{
+		Use:   "version",
+		Short: "Print version information for this executable",
+		Run:   run,
+	}
+)
+
+func init() {
+	root.Command.AddCommand(Command)
+}
+
+func run(cmd *cobra.Command, args []string) {
+	fmt.Println("version:", Config.Version)
+	fmt.Println("commit:", Config.Commit)
+	fmt.Println("date:", Config.Date)
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,17 @@ package main
 
 import "github.com/chirino/graphql-gw/internal/cmd"
 
+// GoReleaser sets these via ldflags:
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
-	cmd.Main()
+	cmd.Main(cmd.VersionConfig{
+		Version: version,
+		Commit:  commit,
+		Date:    date,
+	})
 }


### PR DESCRIPTION
Version info is set on binaries built with goreleaser.