### PR TITLE
feat: Support subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ GraphQL endpoints.
 * Upstream types, that are accessible, are automatically merged into the gateway schema.
 * Type conflict due to the same type name existing in multiple upstream endpoints can be avoided
   by renaming types in the gateway.
-* Supports GraphQL Queries and Mutations
+* Supports GraphQL Queries, Mutations, and Subscriptions
 
 ### Installing
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/chirino/graphql-gw
 
 require (
-	github.com/chirino/graphql v0.0.0-20200504234317-9b3ea07dbe2e
+	github.com/chirino/graphql v0.0.0-20200505162728-9191874ca6d4
 	github.com/ghodss/yaml v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
-github.com/chirino/graphql v0.0.0-20200504234317-9b3ea07dbe2e h1:9uor22tBQXLch45jNFIwjj9TgPk2osnL/S2RenYNSSU=
-github.com/chirino/graphql v0.0.0-20200504234317-9b3ea07dbe2e/go.mod h1:wQjjxFMFyMlsWh4Z3nMuHQtevD4Ul9UVQSnz1JOLuP8=
+github.com/chirino/graphql v0.0.0-20200505162728-9191874ca6d4 h1:InWgtGNYWirAGhscCmlypNAAfziu8HDuQqS9zrk76eo=
+github.com/chirino/graphql v0.0.0-20200505162728-9191874ca6d4/go.mod h1:wQjjxFMFyMlsWh4Z3nMuHQtevD4Ul9UVQSnz1JOLuP8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=

--- a/internal/gateway/examples/starwars-movies/movies.go
+++ b/internal/gateway/examples/starwars-movies/movies.go
@@ -1,12 +1,9 @@
-package characters
+package starwars_characters
 
 import (
-	"reflect"
 	"strings"
-	"time"
 
 	"github.com/chirino/graphql"
-	"github.com/chirino/graphql/resolvers"
 	"github.com/ghodss/yaml"
 )
 
@@ -39,19 +36,14 @@ characters:
 var Schema = `
 	schema {
 		query: Query
-		subscription: Subscription
 	}
 	type Query {
 		characters: [Character!]!
 		search(name:String!): Character
 	}
-	type Subscription {
-		character(id:String!): Character
-	}
 	type Character {
 		id: ID!
 		name: Name
-		likes: Int!
 	}
 	type Name {
 		first: String
@@ -74,34 +66,9 @@ func (r root) Search(args struct{ Name string }) *character {
 	return nil
 }
 
-func (r root) Character(ctx resolvers.ExecutionContext, args struct{ Id string }) {
-	for _, x := range r.Characters {
-		if x.ID == args.Id {
-			go func() {
-				for {
-					select {
-					// Please use the context to know when the subscription is canceled.
-					case <-ctx.GetContext().Done():
-						ctx.FireSubscriptionClose()
-						return
-					case <-time.After(500 * time.Millisecond):
-						// every few  ms... like the character and fire and event.
-						x.Likes += 1
-						ctx.FireSubscriptionEvent(reflect.ValueOf(x), nil)
-					}
-				}
-			}()
-			return
-		}
-	}
-	// no matches..
-	ctx.FireSubscriptionClose()
-}
-
 type character struct {
-	ID    string `json:"id"`
-	Name  name   `json:"name"`
-	Likes int64  `json:"likes"`
+	ID   string `json:"id"`
+	Name name   `json:"name"`
 }
 
 type name struct {

--- a/internal/gateway/examples/starwars-starship/startship.go
+++ b/internal/gateway/examples/starwars-starship/startship.go
@@ -1,12 +1,9 @@
-package characters
+package starwars_starship
 
 import (
-	"reflect"
 	"strings"
-	"time"
 
 	"github.com/chirino/graphql"
-	"github.com/chirino/graphql/resolvers"
 	"github.com/ghodss/yaml"
 )
 
@@ -39,19 +36,14 @@ characters:
 var Schema = `
 	schema {
 		query: Query
-		subscription: Subscription
 	}
 	type Query {
 		characters: [Character!]!
 		search(name:String!): Character
 	}
-	type Subscription {
-		character(id:String!): Character
-	}
 	type Character {
 		id: ID!
 		name: Name
-		likes: Int!
 	}
 	type Name {
 		first: String
@@ -74,34 +66,9 @@ func (r root) Search(args struct{ Name string }) *character {
 	return nil
 }
 
-func (r root) Character(ctx resolvers.ExecutionContext, args struct{ Id string }) {
-	for _, x := range r.Characters {
-		if x.ID == args.Id {
-			go func() {
-				for {
-					select {
-					// Please use the context to know when the subscription is canceled.
-					case <-ctx.GetContext().Done():
-						ctx.FireSubscriptionClose()
-						return
-					case <-time.After(500 * time.Millisecond):
-						// every few  ms... like the character and fire and event.
-						x.Likes += 1
-						ctx.FireSubscriptionEvent(reflect.ValueOf(x), nil)
-					}
-				}
-			}()
-			return
-		}
-	}
-	// no matches..
-	ctx.FireSubscriptionClose()
-}
-
 type character struct {
-	ID    string `json:"id"`
-	Name  name   `json:"name"`
-	Likes int64  `json:"likes"`
+	ID   string `json:"id"`
+	Name name   `json:"name"`
 }
 
 type name struct {


### PR DESCRIPTION
The gateway’s GraphQL endpoint supports WebSocket connections and will establish WebSocket connections to upstream servers to services subscription queries issues by the clients.