### PR TITLE
fix: Remove arm from the release targets

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,18 +13,11 @@ builds:
     goarch:
       - 386
       - amd64
-      - arm
-      - arm64
-    goarm:
-      - 6
-      - 7
 archives:
   - replacements:
       darwin: mac
       386: 32bit-x86
       amd64: 64bit-x86
-      arm: 32bit-arm
-      arm64: 64bit-arm
 
     format_overrides:
       - goos: windows


### PR DESCRIPTION
We currently provide release binaries for arm 
(running gateway on the arm servers will be cool though, but not sure if that was desired or just result from the copy paste I have done)